### PR TITLE
Fix Power Arrow rendering after breaking due to RenderEntity change

### DIFF
--- a/code/Entity/PowerArrow.cs
+++ b/code/Entity/PowerArrow.cs
@@ -16,7 +16,7 @@ namespace Minigolf
 			var offset = endPos - startPos;
 
 			// Line
-			Vertex a = new( size, Vector3.Up, Vector3.Right, new Vector4( 0, 1, 0, 0 ) );
+			Vertex a = new( -size, Vector3.Up, Vector3.Right, new Vector4( 0, 1, 0, 0 ) );
 			Vertex b = new( size, Vector3.Up, Vector3.Right, new Vector4( 1, 1, 0, 0 ) );
 			Vertex c = new( offset + size, Vector3.Up, Vector3.Right, new Vector4( 1, 0, 0, 0 ) );
 			Vertex d = new( offset - size, Vector3.Up, Vector3.Right, new Vector4( 0, 0, 0, 0 ) );

--- a/code/Entity/PowerArrow.cs
+++ b/code/Entity/PowerArrow.cs
@@ -13,11 +13,13 @@ namespace Minigolf
 		{
 			var vertexBuffer = Render.GetDynamicVB( true );
 
+			var offset = endPos - startPos;
+
 			// Line
-			Vertex a = new( startPos - size, Vector3.Up, Vector3.Right, new Vector4( 0, 1, 0, 0 ) );
-			Vertex b = new( startPos + size, Vector3.Up, Vector3.Right, new Vector4( 1, 1, 0, 0 ) );
-			Vertex c = new( endPos + size, Vector3.Up, Vector3.Right, new Vector4( 1, 0, 0, 0 ) );
-			Vertex d = new( endPos - size, Vector3.Up, Vector3.Right, new Vector4( 0, 0, 0, 0 ) );
+			Vertex a = new( size, Vector3.Up, Vector3.Right, new Vector4( 0, 1, 0, 0 ) );
+			Vertex b = new( size, Vector3.Up, Vector3.Right, new Vector4( 1, 1, 0, 0 ) );
+			Vertex c = new( offset + size, Vector3.Up, Vector3.Right, new Vector4( 1, 0, 0, 0 ) );
+			Vertex d = new( offset - size, Vector3.Up, Vector3.Right, new Vector4( 0, 0, 0, 0 ) );
 
 			vertexBuffer.Add( a );
 			vertexBuffer.Add( b );
@@ -30,9 +32,9 @@ namespace Minigolf
 			if (drawTip)
 			{
 				// Add the arrow tip
-				Vertex e = new( endPos + size * 2, Vector3.Up, Vector3.Right, new Vector4( 1, 0, 0, 0 ) );
-				Vertex f = new( endPos - size * 2, Vector3.Up, Vector3.Right, new Vector4( 0, 0, 0, 0 ) );
-				Vertex g = new( endPos + direction * 16 * Power, Vector3.Up, Vector3.Right, new Vector4( 1, 0, 0, 0 ) );
+				Vertex e = new( offset + size * 2, Vector3.Up, Vector3.Right, new Vector4( 1, 0, 0, 0 ) );
+				Vertex f = new( offset - size * 2, Vector3.Up, Vector3.Right, new Vector4( 0, 0, 0, 0 ) );
+				Vertex g = new( offset + direction * 16 * Power, Vector3.Up, Vector3.Right, new Vector4( 1, 0, 0, 0 ) );
 
 				vertexBuffer.Add( e );
 				vertexBuffer.Add( f );

--- a/code/Entity/PowerArrow.cs
+++ b/code/Entity/PowerArrow.cs
@@ -12,9 +12,10 @@ namespace Minigolf
 		protected void DrawArrow( SceneObject obj, Vector3 startPos, Vector3 endPos, Vector3 direction, Vector3 size, Color color, bool drawTip )
 		{
 			var vertexBuffer = Render.GetDynamicVB( true );
-
+			
+			// We need the relative position not the absolute
 			var offset = endPos - startPos;
-
+			
 			// Line
 			Vertex a = new( -size, Vector3.Up, Vector3.Right, new Vector4( 0, 1, 0, 0 ) );
 			Vertex b = new( size, Vector3.Up, Vector3.Right, new Vector4( 1, 1, 0, 0 ) );
@@ -56,14 +57,16 @@ namespace Minigolf
 
 			var startPos = Position;
 			var endPos = Position += Direction * Power * 100;
+
 			var offset = Vector3.Cross( Direction, Vector3.Up ) * (1 + 2 * Power);
 
+			// Trace to check if we go against a wall
 			var trace = Trace.Ray( startPos, endPos );
 			var result = trace.Run();
 
 			var remainingLength = (result.EndPos - endPos).Length;
 
-			// Draw single arrow if no trace
+			// Draw single arrow if no trace/no reflection
 			if ( remainingLength.AlmostEqual(0.0f) )
 			{
 				var color = ColorConvert.HSLToRGB( 120 - (int)(Power * Power * 120), 1.0f, 0.5f );


### PR DESCRIPTION
Fixes #1 

[Breaking Change in RenderEntity](https://github.com/Facepunch/sbox-issues/discussions/568)
[Reference commit in sbox-pool](https://github.com/Facepunch/sbox-pool/commit/23997100529986168f38b940e03e0b801a402ef3)

Before fix:
![](https://user-images.githubusercontent.com/17885980/129890638-b3302086-746c-4020-a956-562ff897cfe5.png)
After fix:
![grafik](https://user-images.githubusercontent.com/17885980/130755354-6c0f1c08-d8c3-4b84-ae67-ff16ccb25b13.png)

Still a bit fucky but idk what causes the arrow to start not at the ball